### PR TITLE
remove overscroll drawing on the left and right

### DIFF
--- a/carousel-view.android.ts
+++ b/carousel-view.android.ts
@@ -332,6 +332,9 @@ function ensureVerticalViewPagerClass() {
                 }})
             );
 
+            // get rid of the overscroll drawing that happens on the left and right
+            global.__native(this).setOverScrollMode(android.view.View.OVER_SCROLL_NEVER);
+
             return global.__native(this);
         }
 


### PR DESCRIPTION
Hi,

just a brief change that removes the incorrect display of the overscroll drawing on the left and right side when you scroll vertically to the beginning/end ( orientation="1" in carousel-view setting).

Seems to be the easiest method according to http://stackoverflow.com/a/22797619/5669456

PS: Thanks for your effort!